### PR TITLE
Improvements for using non-English word lists

### DIFF
--- a/pwgen
+++ b/pwgen
@@ -20,7 +20,7 @@ BEGIN {
     ############################################################################
 
     # Read in the list of words
-    ARGV[1] = "/usr/share/dict/words"
+    ARGV[1] = ARGV[1] ? ARGV[1] : "/usr/share/dict/words"
     ARGC = 2
 
     # Seed the random number generator

--- a/pwgen
+++ b/pwgen
@@ -29,8 +29,8 @@ BEGIN {
 
 # Debian's /usr/share/dict/words has 99171 words, of which 42984 fulfill the 
 # criteria of being eight characters or fewer, and not containing an
-# apostrophe.  This will grab at least 100 words.
-!/'/ && (length($0) <= max_chars) && (rand() < 0.005) {
+# apostrophe or umlaut.  This will grab at least 100 words.
+/^[A-Za-z]+$/ && (length($0) <= max_chars) && (rand() < 0.005) {
     words[i++] = $0
 }
 

--- a/pwgen
+++ b/pwgen
@@ -21,7 +21,7 @@ BEGIN {
 
     # Read in the list of words
     ARGV[1] = ARGV[1] ? ARGV[1] : "/usr/share/dict/words"
-    ARGC = 2
+    ARGC = ARGC > 2 ? ARGC : 2
 
     # Seed the random number generator
     srand()


### PR DESCRIPTION
The first commit allows to specify an alternative word list file on the command-line.

The second commit uses a character whitelist instead of a character blacklist to also suppress words with umlauts or accents as common in German or French word lists.

The third commit allows to specify more than one word list on the command-line, e.g. to mix German and English word lists.
